### PR TITLE
Defines InputConnector class

### DIFF
--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -7,7 +7,7 @@ and ``Input`` objects are used to receive data.
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 
 class BaseConnector:
@@ -54,3 +54,72 @@ class BaseConnector:
         """Return the name of the parent instance"""
 
         return f'<{self.__class__.__name__}(name={self.name}) object at {self._id}>'
+
+
+class InputConnector(BaseConnector):
+    """A queue-like object for handling input data into a node object
+
+    The interface for this class is designed to mimic (but not replace)
+    the built-in ``multiprocessing.Queue`` class.
+    """
+
+    def __init__(self, name: str = None, maxsize: int = None) -> None:
+        """Create a new input connector
+
+        Args:
+            name: Optional name for the connector object
+            maxsize: The maximum number of items to store in connector at once
+        """
+
+        super().__init__(name)
+
+    def empty(self) -> bool:
+        """Return whether the parent connector instance is empty"""
+
+    def full(self) -> bool:
+        """Return whether the parent connector instance is full"""
+
+    def size(self) -> int:
+        """Return the number of items currently stored in the parent instance"""
+
+    @property
+    def maxsize(self) -> Optional[int]:
+        """The maximum number of objects to store in the connector at once"""
+
+    def put(self, item: Any) -> None:
+        """Add an item to the connector queue
+
+        Args:
+            item: The item to add to the connector
+        """
+
+    def get(self, timeout: Optional[int] = None, refresh_interval: int = 2):
+        """Retrieve data from the instance queue
+
+        This is a blocking method and cannot be called asynchronously.
+        Open calls to this method will return automatically should the
+        upstream node object close mid-call.
+
+        Args:
+            timeout: Optionally raise a ``TimeoutError`` if data is not retrieved within the given number of seconds
+            refresh_interval: How often to check if data is expected from upstream
+
+        Raises:
+            TimeOutError: Raised if the method call times out
+        """
+
+    def iter_get(self, timeout: Optional[int] = None, refresh_interval: int = 2) -> Any:
+        """Iterator over data from the instance queue
+
+        Similar to the ``get`` method, but data is returned as an iterable.
+
+        Args:
+            timeout: Raise a TimeoutError if data is not retrieved within the given number of seconds
+            refresh_interval: How often to check if data is expected from upstream
+
+        Raises:
+            TimeOutError: Raised if the get call times out
+        """
+
+    def close(self) -> None:
+        """Close the parent input connector object"""

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -11,6 +11,8 @@ import multiprocessing as mp
 from queue import Empty
 from typing import Any, Optional, Tuple
 
+from egon.exceptions import MissingConnectionError
+
 
 class BaseConnector:
     """Base class for building signal/slot style connectors on top of an underlying queue"""
@@ -153,6 +155,11 @@ class InputConnector(BaseConnector):
         Raises:
             TimeOutError: Raised if the get call times out
         """
+
+        if self.parent_node is None:
+            raise MissingConnectionError(
+                'The ``iter_get`` method cannot be used for ``InputConnector`` instances not assigned to a parent node.'
+            )
 
         while self.parent_node.expecting_data():
             try:

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -99,7 +99,7 @@ class InputConnector(BaseConnector):
 
         return self._queue.maxsize
 
-    def put(self, item: Any) -> None:
+    def _put(self, item: Any) -> None:
         """Add an item to the connector queue
 
         Args:

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -134,6 +134,3 @@ class InputConnector(BaseConnector):
         Raises:
             TimeOutError: Raised if the get call times out
         """
-
-    def close(self) -> None:
-        """Close the parent input connector object"""

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -1,8 +1,11 @@
-"""``Connector`` objects are responsible communicating information
-between nodes. Individual connector instances are assigned to a
+"""``Connector`` objects are responsible for communicating information
+between analysis nodes. Individual connector instances are assigned to a
 single parent node and can be used to send or receive data depending
-on the type of connector. ``Output`` connectors are used to send data
-and ``Input`` objects are used to receive data.
+on the connector type.
+
+``OutputConnector`` objects are used to send data. ``InputConnector`` objects
+are used to receive data. Together, the two connector types implement a
+single/slot style interface for connecting analysis nodes together.
 """
 
 from __future__ import annotations
@@ -20,11 +23,11 @@ class BaseConnector:
     def __init__(self, name: str = None) -> None:
         """Queue-like object for passing data between nodes
 
-        By default, connector names are generated using the instances memory
-        identify in hexadecimal representation.
+        By default, connector names are generated using the instance's memory
+        identifier in hexadecimal representation.
 
         Args:
-            name: Optional name for the connector object
+            name: Set a descriptive name for the connector object
         """
 
         # Identifying information for the instance
@@ -55,7 +58,7 @@ class BaseConnector:
         return bool(self._connected_partners)
 
     def __str__(self) -> str:
-        """Return the name of the parent instance"""
+        """Return a string representation of the parent class"""
 
         return f'<{self.__class__.__name__}(name={self.name}) object at {self._id}>'
 
@@ -71,25 +74,25 @@ class InputConnector(BaseConnector):
         """Create a new input connector
 
         Args:
-            name: Optional name for the connector object
-            maxsize: The maximum number of items to store in connector at once
+            name: Set a descriptive name for the connector object
+            maxsize: The maximum number of items to store in the connector at once
         """
 
         super().__init__(name)
         self._queue = mp.Manager().Queue(maxsize=maxsize or 0)
 
     def empty(self) -> bool:
-        """Return whether the parent connector instance is empty"""
+        """Return whether the connector is empty"""
 
         return self._queue.empty()
 
     def full(self) -> bool:
-        """Return whether the parent connector instance is full"""
+        """Return whether the connector is full"""
 
         return self._queue.full()
 
     def size(self) -> int:
-        """Return the number of items currently stored in the parent instance"""
+        """Return the number of items currently stored in the connector"""
 
         return self._queue.qsize()
 
@@ -100,7 +103,7 @@ class InputConnector(BaseConnector):
         return self._queue.maxsize
 
     def _put(self, item: Any) -> None:
-        """Add an item to the connector queue
+        """Add an item to the connector
 
         Args:
             item: The item to add to the connector
@@ -109,14 +112,14 @@ class InputConnector(BaseConnector):
         self._queue.put(item)
 
     def get(self, timeout: Optional[int] = None, refresh_interval: int = 2) -> Any:
-        """Retrieve data from the instance queue
+        """Retrieve data from the connector
 
         This is a blocking method and cannot be called asynchronously.
-        Open calls to this method will return automatically should the
-        upstream node object close mid-call.
+        Open calls to this method will return automatically if all upstream
+        node objects close mid-call.
 
         Args:
-            timeout: Optionally raise a ``TimeoutError`` if data is not retrieved within the given number of seconds
+            timeout: Raise a ``TimeoutError`` if data is not retrieved within the given number of seconds
             refresh_interval: How often to check if data is expected from upstream
 
         Raises:
@@ -144,16 +147,16 @@ class InputConnector(BaseConnector):
         raise TimeoutError
 
     def iter_get(self, timeout: Optional[int] = None, refresh_interval: int = 2) -> Any:
-        """Iterator over data from the instance queue
+        """Iterate over data from the instance queue
 
         Similar to the ``get`` method, but data is returned as an iterable.
 
         Args:
-            timeout: Raise a TimeoutError if data is not retrieved within the given number of seconds
+            timeout: Raise a ``TimeoutError`` if data is not retrieved within the given number of seconds
             refresh_interval: How often to check if data is expected from upstream
 
         Raises:
-            TimeOutError: Raised if the get call times out
+            TimeOutError: Raised if the method call times out
         """
 
         if self.parent_node is None:

--- a/egon/exceptions.py
+++ b/egon/exceptions.py
@@ -1,0 +1,5 @@
+"""Custom exception classes raised by the porent package."""
+
+
+class MissingConnectionError(Exception):
+    """Raised when data cannot be properly communicated due to a broken connection between Egon objects"""

--- a/tests/test_connectors/test_BaseConnector.py
+++ b/tests/test_connectors/test_BaseConnector.py
@@ -6,7 +6,7 @@ from egon.connectors import BaseConnector
 
 
 class StringRepresentation(TestCase):
-    """Tests for the representation of connector instances as strings"""
+    """Test the representation of connector instances as strings"""
 
     def test_default_name_matches_id(self) -> None:
         """Test the default connector name matches the instance ID"""

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -1,4 +1,5 @@
 """Tests for the ``InputConnector`` class"""
+
 from queue import Empty
 from unittest import TestCase
 
@@ -45,6 +46,7 @@ class QueueProperties(TestCase):
         self.assertTrue(connector.empty())
 
 
+# TODO: Test behavior in relation to parent nodes
 class InputGet(TestCase):
     """Test data retrieval from ``InputConnector`` instances via the ``get`` method"""
 
@@ -71,8 +73,10 @@ class InputGet(TestCase):
     def test_timeout_error(self) -> None:
         """Test a ``TimeoutError`` is raised when fetching an item times out"""
 
+        connector = InputConnector()
+        connector.put(1)
         with self.assertRaises(TimeoutError):
-            InputConnector().get(timeout=0)
+            connector.get(timeout=0)
 
     def test_empty_error(self):
         """Test an ``Empty`` error is raised when fetching from an empty connector"""

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -1,9 +1,10 @@
 """Tests for the ``InputConnector`` class"""
 
 from queue import Empty
-from unittest import TestCase
+from unittest import TestCase, skip
 
 from egon.connectors import InputConnector
+from egon.exceptions import MissingConnectionError
 
 
 class QueueProperties(TestCase):
@@ -47,7 +48,7 @@ class QueueProperties(TestCase):
 
 
 # TODO: Test behavior in relation to parent nodes
-class InputGet(TestCase):
+class Get(TestCase):
     """Test data retrieval from ``InputConnector`` instances via the ``get`` method"""
 
     def test_error_on_zero_refresh(self) -> None:
@@ -83,3 +84,31 @@ class InputGet(TestCase):
 
         with self.assertRaises(Empty):
             InputConnector().get()
+
+
+class IterGet(TestCase):
+    """Test data retrieval from ``InputConnector`` instances via the ``iter_get`` method"""
+
+    @skip('Testing iter_get in this way requires finishing the node classes')
+    def test_returns_queue_values(self) -> None:
+        """Test values are returned from the instance queue"""
+
+        connector = InputConnector()
+        connector.put(1)
+        connector.put(2)
+
+        self.assertSequenceEqual([1, 2], list(connector.iter_get()))
+
+    def test_missing_connection_error(self) -> None:
+        """Test a ``MissingConnectionError`` error is raised if there is no parent node"""
+
+        with self.assertRaises(MissingConnectionError):
+            next(InputConnector().iter_get())
+
+    @skip('Testing iter_get in this way requires finishing the node classes')
+    def test_empty_iterable(self) -> None:
+        """Test the ``iter_get`` method can be used on an empty connector instance"""
+
+        connector = InputConnector()
+        for _ in connector.iter_get():
+            self.fail('No data should have been returned')

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -8,7 +8,7 @@ from egon.exceptions import MissingConnectionError
 
 
 class QueueProperties(TestCase):
-    """Test return values for queue properties by the ``Connector`` class"""
+    """Test queue properties are properly exposed by the ``InputConnector`` class"""
 
     def test_size_matches_queue_size(self) -> None:
         """Test the ``size`` method returns the size of the queue`"""
@@ -64,7 +64,7 @@ class Get(TestCase):
             InputConnector().get(timeout=15, refresh_interval=-1)
 
     def test_returns_queue_value(self) -> None:
-        """Test data is returned the connector queue"""
+        """Test data is returned from the connector queue"""
 
         test_val = 'test_val'
         connector = InputConnector()
@@ -72,14 +72,14 @@ class Get(TestCase):
         self.assertEqual(test_val, connector.get(timeout=1000))
 
     def test_timeout_error(self) -> None:
-        """Test a ``TimeoutError`` is raised when fetching an item times out"""
+        """Test a ``TimeoutError`` is raised when the method times out"""
 
         connector = InputConnector()
         connector._put(1)
         with self.assertRaises(TimeoutError):
             connector.get(timeout=0)
 
-    def test_empty_error(self):
+    def test_empty_error(self) -> None:
         """Test an ``Empty`` error is raised when fetching from an empty connector"""
 
         with self.assertRaises(Empty):
@@ -100,7 +100,7 @@ class IterGet(TestCase):
         self.assertSequenceEqual([1, 2], list(connector.iter_get()))
 
     def test_missing_connection_error(self) -> None:
-        """Test a ``MissingConnectionError`` error is raised if there is no parent node"""
+        """Test a ``MissingConnectionError`` error is raised if the connector has no parent node"""
 
         with self.assertRaises(MissingConnectionError):
             next(InputConnector().iter_get())

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -1,5 +1,5 @@
 """Tests for the ``InputConnector`` class"""
-
+from queue import Empty
 from unittest import TestCase
 
 from egon.connectors import InputConnector
@@ -43,3 +43,39 @@ class QueueProperties(TestCase):
 
         connector.get(1)
         self.assertTrue(connector.empty())
+
+
+class InputGet(TestCase):
+    """Test data retrieval from ``InputConnector`` instances via the ``get`` method"""
+
+    def test_error_on_zero_refresh(self) -> None:
+        """Test a ``ValueError`` is raised when ``refresh_interval`` is zero"""
+
+        with self.assertRaises(ValueError):
+            InputConnector().get(timeout=15, refresh_interval=0)
+
+    def test_error_on_negative_refresh(self) -> None:
+        """Test a ``ValueError`` is raised when ``refresh_interval`` is negative"""
+
+        with self.assertRaises(ValueError):
+            InputConnector().get(timeout=15, refresh_interval=-1)
+
+    def test_returns_queue_value(self) -> None:
+        """Test data is returned the connector queue"""
+
+        test_val = 'test_val'
+        connector = InputConnector()
+        connector.put(test_val)
+        self.assertEqual(test_val, connector.get(timeout=1000))
+
+    def test_timeout_error(self) -> None:
+        """Test a ``TimeoutError`` is raised when fetching an item times out"""
+
+        with self.assertRaises(TimeoutError):
+            InputConnector().get(timeout=0)
+
+    def test_empty_error(self):
+        """Test an ``Empty`` error is raised when fetching from an empty connector"""
+
+        with self.assertRaises(Empty):
+            InputConnector().get()

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -16,7 +16,7 @@ class QueueProperties(TestCase):
         connector = InputConnector(maxsize=1)
         self.assertEqual(connector.size(), 0)
 
-        connector.put(1)
+        connector._put(1)
         self.assertEqual(connector.size(), 1)
 
         connector.get(1)
@@ -28,7 +28,7 @@ class QueueProperties(TestCase):
         connector = InputConnector(maxsize=1)
         self.assertFalse(connector.full())
 
-        connector._queue.put(1)
+        connector._put(1)
         self.assertTrue(connector.full())
 
         connector.get(1)
@@ -40,7 +40,7 @@ class QueueProperties(TestCase):
         connector = InputConnector(maxsize=1)
         self.assertTrue(connector.empty())
 
-        connector._queue.put(1)
+        connector._put(1)
         self.assertFalse(connector.empty())
 
         connector.get(1)
@@ -68,14 +68,14 @@ class Get(TestCase):
 
         test_val = 'test_val'
         connector = InputConnector()
-        connector.put(test_val)
+        connector._put(test_val)
         self.assertEqual(test_val, connector.get(timeout=1000))
 
     def test_timeout_error(self) -> None:
         """Test a ``TimeoutError`` is raised when fetching an item times out"""
 
         connector = InputConnector()
-        connector.put(1)
+        connector._put(1)
         with self.assertRaises(TimeoutError):
             connector.get(timeout=0)
 
@@ -94,8 +94,8 @@ class IterGet(TestCase):
         """Test values are returned from the instance queue"""
 
         connector = InputConnector()
-        connector.put(1)
-        connector.put(2)
+        connector._put(1)
+        connector._put(2)
 
         self.assertSequenceEqual([1, 2], list(connector.iter_get()))
 

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -1,0 +1,45 @@
+"""Tests for the ``InputConnector`` class"""
+
+from unittest import TestCase
+
+from egon.connectors import InputConnector
+
+
+class QueueProperties(TestCase):
+    """Test return values for queue properties by the ``Connector`` class"""
+
+    def test_size_matches_queue_size(self) -> None:
+        """Test the ``size`` method returns the size of the queue`"""
+
+        connector = InputConnector(maxsize=1)
+        self.assertEqual(connector.size(), 0)
+
+        connector.put(1)
+        self.assertEqual(connector.size(), 1)
+
+        connector.get(1)
+        self.assertEqual(connector.size(), 0)
+
+    def test_full_state(self) -> None:
+        """Test the ``full`` method returns whether the queue is full"""
+
+        connector = InputConnector(maxsize=1)
+        self.assertFalse(connector.full())
+
+        connector._queue.put(1)
+        self.assertTrue(connector.full())
+
+        connector.get(1)
+        self.assertFalse(connector.full())
+
+    def test_empty_state(self) -> None:
+        """Test the ``empty`` method returns whether the queue is empty"""
+
+        connector = InputConnector(maxsize=1)
+        self.assertTrue(connector.empty())
+
+        connector._queue.put(1)
+        self.assertFalse(connector.empty())
+
+        connector.get(1)
+        self.assertTrue(connector.empty())


### PR DESCRIPTION
Implements the `InputConnector` class. Some of the functionality cannot be fully tested until `Node` objects are defined in the package. For now, I've roughly (incompletely) implemented those tests and skipped their evaluation by the test suite.