### PR TITLE
Add tests for instantiation of connector objects

### DIFF
--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -32,7 +32,7 @@ class BaseConnector:
 
         # Identifying information for the instance
         self._id = hex(id(self))
-        self.name = str(self._id) if name is None else name
+        self.name = str(name) if name else str(self._id)
 
         # The parent node
         self._node = None

--- a/tests/test_connectors/test_BaseConnector.py
+++ b/tests/test_connectors/test_BaseConnector.py
@@ -5,6 +5,22 @@ from unittest import TestCase
 from egon.connectors import BaseConnector
 
 
+class NameAssignment(TestCase):
+    """Test the dynamic generation of connector names"""
+
+    def test_defaults_to_id(self) -> None:
+        """Test the default connector name matches the memory ID"""
+
+        connector = BaseConnector()
+        self.assertEqual(hex(id(connector)), connector.name)
+
+    def test_custom_name(self) -> None:
+        """Test custom names are assigned to the ``name`` attribute"""
+
+        connector = BaseConnector(name='test_name')
+        self.assertEqual('test_name', connector.name)
+
+
 class StringRepresentation(TestCase):
     """Test the representation of connector instances as strings"""
 

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -7,6 +7,25 @@ from egon.connectors import InputConnector
 from egon.exceptions import MissingConnectionError
 
 
+class MaxSizeValidation(TestCase):
+    """Test errors are raised for invalid ``maxsize`` arguments at init"""
+
+    def test_negative_error(self) -> None:
+        with self.assertRaises(ValueError):
+            InputConnector(maxsize=-1)
+
+        with self.assertRaises(ValueError):
+            InputConnector(maxsize=-1.4)
+
+    def test_float_error(self) -> None:
+        with self.assertRaises(ValueError):
+            InputConnector(maxsize=1.3)
+
+    def test_zero_allowed(self) -> None:
+        connector = InputConnector(maxsize=0)
+        self.assertEqual(0, connector.maxsize)
+
+
 class QueueProperties(TestCase):
     """Test queue properties are properly exposed by the ``InputConnector`` class"""
 
@@ -45,6 +64,12 @@ class QueueProperties(TestCase):
 
         connector.get(1)
         self.assertTrue(connector.empty())
+
+    def test_max_size(self) -> None:
+        """Test the ``maxsize`` attribute returns the maximum queue size"""
+
+        connector = InputConnector(maxsize=1)
+        self.assertEqual(1, connector.maxsize)
 
 
 # TODO: Test behavior in relation to parent nodes

--- a/tests/test_connectors/test_OutputConnector.py
+++ b/tests/test_connectors/test_OutputConnector.py
@@ -7,7 +7,7 @@ from egon.exceptions import MissingConnectionError
 
 
 class Put(TestCase):
-    """Tests for the ``put`` method"""
+    """Test the ``put`` method"""
 
     def test_value_passed_to_input(self) -> None:
         """Test the ``put`` method passes data to connected ``InputConnector`` instances"""
@@ -31,7 +31,7 @@ class Put(TestCase):
 
 
 class Connect(TestCase):
-    """Tests for the ``connect`` method"""
+    """Test the ``connect`` method"""
 
     def test_is_connected(self):
         """Test connector objects are connected by the ``connect`` method"""
@@ -49,13 +49,13 @@ class Connect(TestCase):
         self.assertIn(input_conn, output_conn.partners)
 
     def test_error_on_connection_to_same_type(self) -> None:
-        """Test an error is raised when connecting two outputs together"""
+        """Test a ``ValueError`` is raised when connecting two outputs together"""
 
         with self.assertRaises(ValueError):
             OutputConnector().connect(OutputConnector())
 
     def test_duplicate_connections(self) -> None:
-        """Test an error is raised when trying to overwrite an existing connection"""
+        """Test duplicate connections cannot be created between inputs and outputs"""
 
         input_conn = InputConnector()
         output_conn = OutputConnector()
@@ -67,7 +67,7 @@ class Connect(TestCase):
 
 
 class Disconnect(TestCase):
-    """Tests for the ``disconnect`` method"""
+    """Test the ``disconnect`` method"""
 
     def test_both_connectors_are_disconnected(self) -> None:
         """Test both connectors are no longer listed as partners"""


### PR DESCRIPTION
Adds tests to ensure:

1. The max size value is set for input queues
2. Name values are dynamically assigned

Apparently, the `.maxsize` attribute is not an official part of the Python multiprocessing API. Instead, I've started tracking the max size attribute manually within the `InputConnector` class. 