### PR TITLE
Adds helper methods for modifying connector partners

### DIFF
--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -75,7 +75,7 @@ class BaseConnector:
 
         return bool(self._connected_partners)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return a string representation of the parent class"""
 
         return f'<{self.__class__.__name__}(name={self.name}) object at {self._id}>'

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -46,6 +46,24 @@ class BaseConnector:
 
         return self._node
 
+    def _add_partner(self, other: BaseConnector) -> None:
+        """Add a partner connector
+
+        Args:
+            other: The connector to add
+        """
+
+        self._connected_partners.add(other)
+
+    def _remove_partner(self, other: BaseConnector) -> None:
+        """Remove a partner connector
+
+        Args:
+            other: The connector to remove
+        """
+
+        self._connected_partners.remove(other)
+
     @property
     def partners(self) -> Tuple[BaseConnector]:
         """Return a tuple of connectors that are connected to this instance"""
@@ -198,8 +216,8 @@ class OutputConnector(BaseConnector):
         if type(conn) is type(self):
             raise ValueError('Cannot join together two connector objects of the same type.')
 
-        self._connected_partners.add(conn)
-        conn._connected_partners.add(self)
+        self._add_partner(conn)
+        conn._add_partner(self)
 
     def disconnect(self, conn: InputConnector) -> None:
         """Disconnect an established connection to the given ``InputConnector`` instance
@@ -215,8 +233,8 @@ class OutputConnector(BaseConnector):
             raise MissingConnectionError('The given connector object is not connected to this instance')
 
         # Disconnect both connectors from each other
-        conn._connected_partners.remove(self)
-        self._connected_partners.remove(conn)
+        conn._remove_partner(self)
+        self._remove_partner(conn)
 
     def put(self, item: Any) -> None:
         """Add an item to the connector queue

--- a/tests/test_connectors/test_BaseConnector.py
+++ b/tests/test_connectors/test_BaseConnector.py
@@ -24,12 +24,6 @@ class NameAssignment(TestCase):
 class StringRepresentation(TestCase):
     """Test the representation of connector instances as strings"""
 
-    def test_default_name_matches_id(self) -> None:
-        """Test the default connector name matches the instance ID"""
-
-        connector = BaseConnector()
-        self.assertEqual(hex(id(connector)), connector.name)
-
     def test_string_representation(self) -> None:
         """Test connectors include name and ID info when cast to a string"""
 
@@ -38,3 +32,9 @@ class StringRepresentation(TestCase):
 
         expected_string = f'<BaseConnector(name={connector_name}) object at {hex(id(connector))}>'
         self.assertEqual(expected_string, str(connector))
+
+    def test_repr_matches_string(self) -> None:
+        """Test the ``str`` and ``repr`` strings are the same"""
+
+        connector = BaseConnector()
+        self.assertEqual(repr(connector), str(connector))


### PR DESCRIPTION
This PR adds the `_add_partner` and `_remove_partner` methods to the `BaseConnector` class. The change is purely a design change. It abstracts away the process to make things clearer and easier to debug.