### PR TITLE
Extends connector tests to reflect new Node class

### DIFF
--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -155,6 +155,7 @@ class InputConnector(BaseConnector):
 
         Raises:
             TimeOutError: Raised if the method call times out
+            Empty: When there is no data to return
         """
 
         if timeout is None:

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -197,7 +197,7 @@ class InputConnector(BaseConnector):
                 'The ``iter_get`` method cannot be used for ``InputConnector`` instances not assigned to a parent node.'
             )
 
-        while self.parent_node.expecting_data():
+        while self.parent_node.is_expecting_data():
             try:
                 yield self.get(timeout=timeout, refresh_interval=refresh_interval)
 

--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -157,19 +157,20 @@ class InputConnector(BaseConnector):
             TimeOutError: Raised if the method call times out
         """
 
-        if refresh_interval <= 0:
-            raise ValueError('Connector refresh interval must be greater than zero.')
-
         if timeout is None:
             timeout = float('inf')
 
+        if refresh_interval <= 0 or timeout < 0:
+            raise ValueError('Connector refresh and timeout intervals must be greater than zero.')
+
         while timeout > 0:
             this_timeout = min(timeout, refresh_interval)
+            timeout -= this_timeout
+
             try:
                 return self._queue.get(timeout=this_timeout)
 
             except (Empty, TimeoutError):
-                timeout -= this_timeout
                 if self.parent_node and self.parent_node.is_expecting_data():
                     continue
 

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -12,6 +12,8 @@ class DummyUpstreamNode(Node):
     """Dummy node with a single output for running tests"""
 
     def __init__(self):
+        """Define a single output connector"""
+
         super().__init__(1)
         self.output = self.create_output()
 
@@ -23,6 +25,8 @@ class DummyDownstreamNode(Node):
     """Dummy node with a single input for running tests"""
 
     def __init__(self):
+        """Define a single input connector"""
+
         super().__init__(1)
         self.input = self.create_input()
 

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -95,7 +95,6 @@ class QueueProperties(TestCase):
         self.assertEqual(1, connector.maxsize)
 
 
-# TODO: Test behavior in relation to parent nodes
 class Get(TestCase):
     """Test data retrieval from ``InputConnector`` instances via the ``get`` method"""
 
@@ -110,6 +109,12 @@ class Get(TestCase):
 
         with self.assertRaises(ValueError):
             InputConnector().get(timeout=15, refresh_interval=-1)
+
+    def test_error_on_negative_timeout(self) -> None:
+        """Test a ``ValueError`` is raised when ``timeout`` is negative"""
+
+        with self.assertRaises(ValueError):
+            InputConnector().get(timeout=-1)
 
     def test_returns_queue_value(self) -> None:
         """Test data is returned from the connector queue"""
@@ -150,6 +155,7 @@ class IterGet(TestCase):
         self.upstream.output.put(1)
         self.upstream.output.put(2)
         self.upstream.execute()
+        self.downstream.execute()
 
         self.assertSequenceEqual([1, 2], list(self.downstream.input.iter_get()))
 
@@ -163,5 +169,6 @@ class IterGet(TestCase):
         """Test the ``iter_get`` method can be used on an empty connector instance"""
 
         self.upstream.execute()
+        self.downstream.execute()
         for _ in self.downstream.input.iter_get():
             self.fail('No data should have been returned')


### PR DESCRIPTION
PR #10 implemented the `Node` class. This PR updates tests for the connector classes to reflect the relationship between connectors and nodes.