### PR TITLE
Imports key classes into package level init

### DIFF
--- a/egon/__init__.py
+++ b/egon/__init__.py
@@ -1,3 +1,7 @@
 """A Python parallelization framework for easily building powerful data analysis networks."""
 
+from .connectors import InputConnector, OutputConnector
+from .nodes import Node
+from .pipeline import Pipeline
+
 __version__ = '0.0.0'

--- a/tests/test_connectors/test_BaseConnector.py
+++ b/tests/test_connectors/test_BaseConnector.py
@@ -2,8 +2,8 @@
 
 from unittest import TestCase
 
+from egon import Node
 from egon.connectors import BaseConnector
-from egon.nodes import Node
 
 
 class TestNode(Node):

--- a/tests/test_connectors/test_InputConnector.py
+++ b/tests/test_connectors/test_InputConnector.py
@@ -3,9 +3,8 @@
 from queue import Empty
 from unittest import TestCase
 
-from egon.connectors import InputConnector
+from egon import InputConnector, Node
 from egon.exceptions import MissingConnectionError
-from egon.nodes import Node
 
 
 class DummyUpstreamNode(Node):

--- a/tests/test_connectors/test_OutputConnector.py
+++ b/tests/test_connectors/test_OutputConnector.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase
 
-from egon.connectors import InputConnector, OutputConnector
+from egon import InputConnector, OutputConnector
 from egon.exceptions import MissingConnectionError
 
 

--- a/tests/test_nodes/test_Node.py
+++ b/tests/test_nodes/test_Node.py
@@ -3,8 +3,8 @@
 from unittest import TestCase
 from unittest.mock import Mock, call
 
+from egon import Node
 from egon.exceptions import NodeValidationError
-from egon.nodes import Node
 
 
 class TestNode(Node):

--- a/tests/test_pipeline/test_Pipeline.py
+++ b/tests/test_pipeline/test_Pipeline.py
@@ -3,9 +3,8 @@
 from time import sleep
 from unittest import TestCase
 
+from egon import Node, Pipeline
 from egon.exceptions import PipelineValidationError
-from egon.nodes import Node
-from egon.pipeline import Pipeline
 
 
 class Dummy(Node):


### PR DESCRIPTION
The `Node`, `Pipeline`, and connector classes have been imported into the package level init file. This makes for a cleaner import structure (from the user's perspective).