### PR TITLE
Uses UUID to identify connectors, nodes, and pipelines

### DIFF
--- a/egon/connectors.py
+++ b/egon/connectors.py
@@ -11,6 +11,7 @@ single/slot style interface for connecting analysis nodes together.
 from __future__ import annotations
 
 import multiprocessing as mp
+import uuid
 from queue import Empty
 from typing import Any, Optional, Set, TYPE_CHECKING, Tuple
 
@@ -35,7 +36,7 @@ class BaseConnector:
         """
 
         # Identifying information for the instance
-        self._id = hex(id(self))
+        self._id = str(uuid.uuid4())
         self.name = str(name) if name else str(self._id)
 
         # The parent node
@@ -43,6 +44,12 @@ class BaseConnector:
 
         # Other connector objects connected to this instance
         self._connected_partners: Set[BaseConnector] = set()
+
+    @property
+    def id(self) -> str:
+        """Return the universally unique identifier for the parent node"""
+
+        return self._id
 
     @property
     def parent_node(self) -> Optional[Node]:

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -5,6 +5,7 @@ pipeline.
 from __future__ import annotations
 
 import abc
+import uuid
 from typing import Tuple
 
 from .connectors import InputConnector, OutputConnector
@@ -29,6 +30,13 @@ class Node(abc.ABC):
         self._engine = MultiprocessingEngine(num_processes, self._execute_helper)
         self._inputs = []
         self._outputs = []
+        self._id = str(uuid.uuid4())
+
+    @property
+    def id(self) -> str:
+        """Return the universally unique identifier for the parent node"""
+
+        return self._id
 
     def get_num_processes(self) -> int:
         """Return number of processes assigned to the analysis node"""

--- a/egon/pipelines.py
+++ b/egon/pipelines.py
@@ -2,6 +2,7 @@
 execution of multiple analysis nodes.
 """
 
+import uuid
 from typing import Dict, Tuple, Type, TypeVar
 
 from .exceptions import PipelineValidationError
@@ -20,6 +21,13 @@ class Pipeline:
         """
 
         self._nodes = []
+        self._id = str(uuid.uuid4())
+
+    @property
+    def id(self) -> str:
+        """Return the universally unique identifier for the parent node"""
+
+        return self._id
 
     def create_node(self, node_class: Type[NODE_TYPE], /, *args, **kwargs) -> NODE_TYPE:
         """Create a new analysis node and attach it to the current pipeline

--- a/tests/test_connectors/test_BaseConnector.py
+++ b/tests/test_connectors/test_BaseConnector.py
@@ -20,13 +20,22 @@ class NameAssignment(TestCase):
         """Test the default connector name matches the memory ID"""
 
         connector = BaseConnector()
-        self.assertEqual(hex(id(connector)), connector.name)
+        self.assertEqual(connector.id, connector.name)
 
     def test_custom_name(self) -> None:
         """Test custom names are assigned to the ``name`` attribute"""
 
         connector = BaseConnector(name='test_name')
         self.assertEqual('test_name', connector.name)
+
+
+class IDAssignment(TestCase):
+    """Test the generation of instance ID values"""
+
+    def test_is_uuid_format(self) -> None:
+        """Test the instance ID is in UUID4 format"""
+
+        self.assertRegex(TestNode().id, r'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
 
 
 class ParentNode(TestCase):
@@ -49,7 +58,7 @@ class StringRepresentation(TestCase):
         connector_name = 'my_connector'
         connector = BaseConnector(name=connector_name)
 
-        expected_string = f'<BaseConnector(name={connector_name}) object at {hex(id(connector))}>'
+        expected_string = f'<BaseConnector(name={connector_name}) object at {connector.id}>'
         self.assertEqual(expected_string, str(connector))
 
     def test_repr_matches_string(self) -> None:

--- a/tests/test_pipeline/test_Pipeline.py
+++ b/tests/test_pipeline/test_Pipeline.py
@@ -48,6 +48,15 @@ def disconnected_pipeline() -> Pipeline:
     return pipe
 
 
+class IDAssignment(TestCase):
+    """Test the generation of instance ID values"""
+
+    def test_is_uuid_format(self) -> None:
+        """Test the instance ID is in UUID4 format"""
+
+        self.assertRegex(valid_pipeline().id, r'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
+
+
 class Validation(TestCase):
     """Tests the ``validation`` method"""
 


### PR DESCRIPTION
IDs were previously generated using the instance memory address. The PR migrates to using UUIDs instead. ID values are also exposed via an `id` property.