### PR TITLE
Adds a shortcut syntax for generating dynamic connectors

### DIFF
--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -35,10 +35,26 @@ class Node(abc.ABC):
 
         # Dynamically create input/output connectors based on class attributes
         for output_spec in self.egon_outputs:
+            self._raise_for_invalid_identifier(output_spec)
             setattr(self, output_spec, self.create_output(output_spec))
 
         for input_spec in self.egon_inputs:
+            self._raise_for_invalid_identifier(input_spec)
             setattr(self, input_spec, self.create_input(input_spec))
+
+    @staticmethod
+    def _raise_for_invalid_identifier(val: str) -> None:
+        """Raise an error if the given string is not a valid python identifier
+
+        Args:
+            val: The string to validate
+
+        Raises:
+            ValueError: For an invalid identifier
+        """
+
+        if not val.isidentifier():
+            raise ValueError(f'Invalid name for connector: {val}')
 
     def get_num_processes(self) -> int:
         """Return number of processes assigned to the analysis node"""

--- a/egon/nodes.py
+++ b/egon/nodes.py
@@ -15,6 +15,9 @@ from .multiprocessing import MultiprocessingEngine
 class Node(abc.ABC):
     """Abstract base class for constructing analysis nodes"""
 
+    egon_inputs: Tuple[str] = tuple()
+    egon_outputs: Tuple[str] = tuple()
+
     def __init__(self, num_processes: int = 1, name: str = None) -> None:
         """Instantiate a new pipeline node
 
@@ -29,6 +32,13 @@ class Node(abc.ABC):
         self._engine = MultiprocessingEngine(num_processes, self._execute_helper)
         self._inputs = []
         self._outputs = []
+
+        # Dynamically create input/output connectors based on class attributes
+        for output_spec in self.egon_outputs:
+            setattr(self, output_spec, self.create_output(output_spec))
+
+        for input_spec in self.egon_inputs:
+            setattr(self, input_spec, self.create_input(input_spec))
 
     def get_num_processes(self) -> int:
         """Return number of processes assigned to the analysis node"""

--- a/tests/functional_tests/test_even_odd_pipeline.py
+++ b/tests/functional_tests/test_even_odd_pipeline.py
@@ -15,7 +15,7 @@ from multiprocessing import Queue
 from queue import Empty
 from unittest import TestCase
 
-from egon import Node, Pipeline
+from egon import Node, Pipeline, OutputConnector, InputConnector
 
 # Input queues for feeding even/odd numbers into the pipeline
 EVEN_INPUT_QUEUE = Queue()
@@ -38,7 +38,7 @@ for i in ODD_INPUT_VALUES:
 class EvenNumberGenerator(Node):
     """Pipeline node for generating even integers"""
 
-    egon_outputs = ('output',)
+    output: OutputConnector
 
     def action(self) -> None:
         """Populate the node output with even integers"""
@@ -54,7 +54,7 @@ class EvenNumberGenerator(Node):
 class OddNumberGenerator(Node):
     """Pipeline node for generating odd integers"""
 
-    egon_outputs = ('output',)
+    output: OutputConnector
 
     def action(self) -> None:
         """Populate the node output with odd integers"""
@@ -70,8 +70,9 @@ class OddNumberGenerator(Node):
 class NumberSorter(Node):
     """Sort numbers into different outputs depending on whether they are odd or even"""
 
-    egon_inputs = ('input',)
-    egon_outputs = ('even_output', 'odd_output')
+    input: InputConnector
+    even_output: OutputConnector
+    odd_output: OutputConnector
 
     def action(self) -> None:
         """Sort numbers into odds and evens"""
@@ -87,7 +88,7 @@ class NumberSorter(Node):
 class EvenNumberCollector(Node):
     """Load even numbers into a global queue"""
 
-    egon_inputs = ('input',)
+    input: InputConnector
 
     def action(self) -> None:
         """Load pipeline values into the ``EVEN_OUTPUT_QUEUE`` collection"""
@@ -99,7 +100,7 @@ class EvenNumberCollector(Node):
 class OddNumberCollector(Node):
     """Load odd numbers into a global queue"""
 
-    egon_inputs = ('input',)
+    input: InputConnector
 
     def action(self) -> None:
         """Load pipeline values into the ``ODD_OUTPUT_QUEUE`` collection"""

--- a/tests/functional_tests/test_even_odd_pipeline.py
+++ b/tests/functional_tests/test_even_odd_pipeline.py
@@ -38,11 +38,7 @@ for i in ODD_INPUT_VALUES:
 class EvenNumberGenerator(Node):
     """Pipeline node for generating even integers"""
 
-    def __init__(self, num_processes: int = 1) -> None:
-        """Define a pipeline node with a single output"""
-
-        super().__init__(num_processes=num_processes)
-        self.output = self.create_output()
+    egon_outputs = ('output',)
 
     def action(self) -> None:
         """Populate the node output with even integers"""
@@ -58,11 +54,7 @@ class EvenNumberGenerator(Node):
 class OddNumberGenerator(Node):
     """Pipeline node for generating odd integers"""
 
-    def __init__(self, num_processes: int = 1) -> None:
-        """Define a pipeline node with a single output"""
-
-        super().__init__(num_processes=num_processes)
-        self.output = self.create_output()
+    egon_outputs = ('output',)
 
     def action(self) -> None:
         """Populate the node output with odd integers"""
@@ -78,13 +70,8 @@ class OddNumberGenerator(Node):
 class NumberSorter(Node):
     """Sort numbers into different outputs depending on whether they are odd or even"""
 
-    def __init__(self, num_processes: int = 1) -> None:
-        """Define """
-
-        super().__init__(num_processes=num_processes)
-        self.input = self.create_input()
-        self.even_output = self.create_output('Even Numbers')
-        self.odd_output = self.create_output('Odd Numbers')
+    egon_inputs = ('input',)
+    egon_outputs = ('even_output', 'odd_output')
 
     def action(self) -> None:
         """Sort numbers into odds and evens"""
@@ -100,11 +87,7 @@ class NumberSorter(Node):
 class EvenNumberCollector(Node):
     """Load even numbers into a global queue"""
 
-    def __init__(self, num_processes: int = 1) -> None:
-        """Define a pipeline node with a single input"""
-
-        super().__init__(num_processes=num_processes)
-        self.input = self.create_input()
+    egon_inputs = ('input',)
 
     def action(self) -> None:
         """Load pipeline values into the ``EVEN_OUTPUT_QUEUE`` collection"""
@@ -116,11 +99,7 @@ class EvenNumberCollector(Node):
 class OddNumberCollector(Node):
     """Load odd numbers into a global queue"""
 
-    def __init__(self, num_processes: int = 1) -> None:
-        """Define a pipeline node with a single input"""
-
-        super().__init__(num_processes=num_processes)
-        self.input = self.create_input()
+    egon_inputs = ('input',)
 
     def action(self) -> None:
         """Load pipeline values into the ``ODD_OUTPUT_QUEUE`` collection"""

--- a/tests/test_nodes/test_Node.py
+++ b/tests/test_nodes/test_Node.py
@@ -51,6 +51,25 @@ class ProcessAllocation(TestCase):
             TestNode(num_processes=0)
 
 
+class DynamicConnectorAssignment(TestCase):
+    """Test dynamic connector creation from class attributes"""
+
+    def test_connector_assignment(self) -> None:
+        """Test connectors are created dynamically from class attributes"""
+
+        class DynamicTestNode(TestNode):
+            """Dummy node with two inputs and two outputs"""
+
+            egon_inputs = ('input1', 'input2')
+            egon_outputs = ('output1', 'output2')
+
+        node = DynamicTestNode()
+        self.assertTrue(hasattr(node, 'input1'))
+        self.assertTrue(hasattr(node, 'input2'))
+        self.assertTrue(hasattr(node, 'output1'))
+        self.assertTrue(hasattr(node, 'output2'))
+
+
 class SetNumProcesses(TestCase):
     """Test setting/getting the number of node processes"""
 

--- a/tests/test_nodes/test_Node.py
+++ b/tests/test_nodes/test_Node.py
@@ -58,7 +58,7 @@ class DynamicConnectorAssignment(TestCase):
         """Test connectors are created dynamically from class attributes"""
 
         class DynamicTestNode(TestNode):
-            """Dummy node with two inputs and two outputs"""
+            """Dummy node with dynamic connectors"""
 
             egon_inputs = ('input1', 'input2')
             egon_outputs = ('output1', 'output2')
@@ -68,6 +68,51 @@ class DynamicConnectorAssignment(TestCase):
         self.assertTrue(hasattr(node, 'input2'))
         self.assertTrue(hasattr(node, 'output1'))
         self.assertTrue(hasattr(node, 'output2'))
+
+    def test_no_max_size(self) -> None:
+        """Test dynamically created input connectors have no maximum size"""
+
+        class DynamicTestNode(TestNode):
+            """Dummy node with dynamic connectors"""
+
+            egon_inputs = ('input1',)
+
+        node = DynamicTestNode()
+        self.assertFalse(node.input1.maxsize)
+
+    def test_node_names(self) -> None:
+        """Test nodes are assigned their given names"""
+
+        class DynamicTestNode(TestNode):
+            """Dummy node with dynamic connectors"""
+
+            egon_inputs = ('first_input', 'second_input')
+
+        node = DynamicTestNode()
+        self.assertEqual('first_input', node.first_input.name)
+        self.assertEqual('second_input', node.second_input.name)
+
+    def test_whitespace_name_error(self) -> None:
+        """Test a ``ValueError`` is raised for connector names with whitespace"""
+
+        class DynamicTestNode(TestNode):
+            """Dummy node with dynamic connectors"""
+
+            egon_inputs = ('first input',)
+
+        with self.assertRaises(ValueError):
+            DynamicTestNode()
+
+    def test_numeric_name_error(self) -> None:
+        """Test a ``ValueError`` is raised for connector names starting with a number"""
+
+        class DynamicTestNode(TestNode):
+            """Dummy node with dynamic connectors"""
+
+            egon_inputs = ('1input',)
+
+        with self.assertRaises(ValueError):
+            DynamicTestNode()
 
 
 class SetNumProcesses(TestCase):


### PR DESCRIPTION
With this PR, connectors can be added by specifying class level typing annotations. This removes the need to write an init function just to define the connectors.