### PR TITLE
Switches to Poetry for packaging

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,43 @@
+name: PyPi
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  test:
+    name: Run Tests
+    uses: ./.github/workflows/Unittests.yml
+    secrets: inherit
+
+  build:
+    name: Build Source Distribution
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Set package version
+        run: |
+          tag=${{github.ref}}
+          poetry version "${tag:1}"
+
+      - name: Build package
+        run: poetry build -v
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          user: ${{ secrets.PYPI_USER }}
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package dependencies
-        run: pip install .[tests]
+        run: pip install coverage .
 
       - name: Run tests with coverage
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
-[build-system]
-requires = ["setuptools>=64.0"]
-build-backend = "setuptools.build_meta"
-
-[project]
+[tool.poetry]
 name = "egon"
-dynamic = ["version"]
+version = "0.0.0"  # Version is set automatically via CI
+authors = ["Daniel Perrefort", ]
 description = "A Python parallelization framework for easily building powerful data analysis networks."
+readme = "README.md"
+repository = "https://github.com/Egon-Framework/egon"
 keywords = ["parallel", "multiprocessing", "pipeline", "network", "framework"]
 classifiers = [
     "Intended Audience :: Developers",
@@ -17,18 +16,10 @@ classifiers = [
     "Topic :: Software Development",
     "Typing :: Typed"
 ]
-requires-python = ">=3.7"
-dependencies = []
 
-[[project.authors]]
-name = "Daniel Perrefort"
+[tool.poetry.dependencies]
+python = "^3.7"
 
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
-[project.optional-dependencies]
-tests = ["coverage", ]
-
-[tool.setuptools.dynamic]
-version = { attr = "egon.__version__" }
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR switches the packaging backed to Poetry and adds a CI workflow for publishing the package.

Poetry includes more extensive build tools making it easier to manage development environments and package publication.