### PR TITLE
Bumps minimum python requirments to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The packaging toml file specifies Python `^3.7` but should list `^3.8`. Some of the syntax we use is not available in 3.7.