### PR TITLE
Raises an error when running engine instances concurrently

### DIFF
--- a/egon/multiprocessing.py
+++ b/egon/multiprocessing.py
@@ -87,6 +87,9 @@ class MultiprocessingEngine:
     def run_async(self) -> None:
         """Start all processes asynchronously"""
 
+        if self._locked:
+            raise RuntimeError('Cannot start a process pool twice.')
+
         self._locked = True
         for p in self._processes:
             p.start()

--- a/tests/test_multiprocessing/test_MultiprocessingEngine.py
+++ b/tests/test_multiprocessing/test_MultiprocessingEngine.py
@@ -163,6 +163,16 @@ class RunAsync(TestCase):
 
         engine.kill()
 
+    def test_concurrent_run_error(self) -> None:
+        """Test an error is raised when the engine is already running"""
+
+        engine = MultiprocessingEngine(num_processes=4, target=lambda: sleep(5))
+        engine.run_async()
+        with self.assertRaises(RuntimeError):
+            engine.run_async()
+
+        engine.kill()
+
 
 class Run(TestCase):
     """Test the ``run`` method"""
@@ -176,6 +186,16 @@ class Run(TestCase):
         engine.run()
 
         self.assertEqual(4, len(shared_list))
+
+    def test_concurrent_run_error(self) -> None:
+        """Test an error is raised when the engine is already running"""
+
+        engine = MultiprocessingEngine(num_processes=4, target=lambda: sleep(5))
+        engine.run_async()
+        with self.assertRaises(RuntimeError):
+            engine.run()
+
+        engine.kill()
 
 
 class Join(TestCase):


### PR DESCRIPTION
I started thinking about what happens when pipeline nodes are run manually **before** launching the pipeline. At first I was concerned about unexpected behavior, but it turns out this was already handled by an assertion error in the multiprocessing library. I've added an explicit exception to prevent the assertion from getting stripped by the Python optimization flag - just in case.